### PR TITLE
#28 REST API 예외 처리

### DIFF
--- a/src/main/java/kr/hs/mirim/family/exception/DataNotFoundException.java
+++ b/src/main/java/kr/hs/mirim/family/exception/DataNotFoundException.java
@@ -1,0 +1,12 @@
+package kr.hs.mirim.family.exception;
+
+import kr.hs.mirim.family.exception.handler.ApiException;
+import org.springframework.http.HttpStatus;
+
+public class DataNotFoundException extends ApiException {
+    private static final int status = HttpStatus.NOT_FOUND.value();
+
+    public DataNotFoundException(String message) {
+        super(status, message);
+    }
+}

--- a/src/main/java/kr/hs/mirim/family/exception/handler/ApiException.java
+++ b/src/main/java/kr/hs/mirim/family/exception/handler/ApiException.java
@@ -1,0 +1,15 @@
+package kr.hs.mirim.family.exception.handler;
+
+import lombok.Getter;
+
+@Getter
+public class ApiException extends RuntimeException {
+    private final int status;
+    private final String message;
+
+    protected ApiException(int status, String message) {
+        super(message);
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/kr/hs/mirim/family/exception/handler/ApiExceptionAdvice.java
+++ b/src/main/java/kr/hs/mirim/family/exception/handler/ApiExceptionAdvice.java
@@ -1,0 +1,51 @@
+package kr.hs.mirim.family.exception.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Slf4j
+@RestControllerAdvice
+public class ApiExceptionAdvice {
+
+    @ExceptionHandler({ApiException.class})
+    protected ResponseEntity<ErrorResponse> ApiException(final ApiException e) {
+        return new ResponseEntity<>(new ErrorResponse(e.getStatus(), e.getMessage()), HttpStatus.valueOf(e.getStatus()));
+    }
+
+    @ExceptionHandler({MethodArgumentNotValidException.class})
+    protected ResponseEntity<ErrorResponse> MethodArgumentNotValidExceptionHandler(final MethodArgumentNotValidException e) {
+        log.error(e.getCause().getMessage());
+        return new ResponseEntity<>(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), e.getLocalizedMessage()), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler({Exception.class})
+    protected ResponseEntity<ErrorResponse> ExceptionHandler(final Exception e) {
+        log.error(e.getCause().getMessage());
+        return new ResponseEntity<>(new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getLocalizedMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler({DataIntegrityViolationException.class})
+    protected ResponseEntity<ErrorResponse> DataIntegrityViolationExceptionHandler(final DataIntegrityViolationException e) {
+        log.error(e.getCause().getMessage());
+        return new ResponseEntity<>(new ErrorResponse(HttpStatus.CONFLICT.value(), e.getLocalizedMessage()), HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler({MethodArgumentTypeMismatchException.class})
+    protected ResponseEntity<ErrorResponse> MethodArgumentTypeMismatchExceptionHandler(final MethodArgumentTypeMismatchException e) {
+        log.error(e.getCause().getMessage());
+        return new ResponseEntity<>(new ErrorResponse(HttpStatus.BAD_REQUEST.value(), e.getLocalizedMessage()), HttpStatus.BAD_REQUEST);
+    }
+    @ExceptionHandler({HttpRequestMethodNotSupportedException.class})
+    protected ResponseEntity<ErrorResponse> HttpRequestMethodNotSupportedExceptionHandler(final HttpRequestMethodNotSupportedException e) {
+        log.error(e.getCause().getMessage());
+        return new ResponseEntity<>(new ErrorResponse(HttpStatus.METHOD_NOT_ALLOWED.value(), e.getLocalizedMessage()), HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+}

--- a/src/main/java/kr/hs/mirim/family/exception/handler/ErrorResponse.java
+++ b/src/main/java/kr/hs/mirim/family/exception/handler/ErrorResponse.java
@@ -1,0 +1,11 @@
+package kr.hs.mirim.family.exception.handler;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ErrorResponse {
+    private int status;
+    private String message;
+}


### PR DESCRIPTION
- 지난 스터디에서는 enum으로 에러 코드와 메시지를 작성하여 예외처리를 진행했었다. 이번 프로젝트에서는 에러 코드에 해당하는 생성자에 메시지를 매개변수로 작성하는 방법으로 진행할 것이다.
- enum을 작성하지 않고 메시지만 넘기면 되어서 전보다 간편해졌다.

### 사용 방법

```java
throw new DataNotFoundException("User Not Found");
```

- 상태 코드에 해당하는 생성자 호출
- 생성자 매개변수로 메시지 넘기기


```java
public class 예외처리이름Exception extends ApiException {
		// 상태 코드
    private static final int status = HttpStatus.상태명.value();

		// 메시지 매개변수로 받음
    public 예외처리이름Exception(String message) {
        super(status, message);
    }
}
```
