### PR TITLE
#7 심부름 추가 기능 구현

### DIFF
--- a/src/main/java/kr/hs/mirim/family/controller/QuestController.java
+++ b/src/main/java/kr/hs/mirim/family/controller/QuestController.java
@@ -1,0 +1,29 @@
+package kr.hs.mirim.family.controller;
+
+import kr.hs.mirim.family.dto.request.CreateGroupRequest;
+import kr.hs.mirim.family.dto.request.CreateQuestRequest;
+import kr.hs.mirim.family.service.GroupService;
+import kr.hs.mirim.family.service.QuestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(value = "groups/{groupId}/quests")
+public class QuestController {
+    private final QuestService questService;
+
+    @PostMapping("/{userId}")
+    public void createQuest(
+            @Valid @RequestBody CreateQuestRequest request,
+            BindingResult bindingResult,
+            @PathVariable long groupId,
+            @PathVariable long userId
+    ) {
+        questService.createQuest(groupId, userId, request, bindingResult);
+    }
+
+}

--- a/src/main/java/kr/hs/mirim/family/dto/request/CreateQuestRequest.java
+++ b/src/main/java/kr/hs/mirim/family/dto/request/CreateQuestRequest.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 @Getter
 @AllArgsConstructor
@@ -12,6 +13,6 @@ import javax.validation.constraints.NotEmpty;
 public class CreateQuestRequest {
     @NotEmpty
     private String questTitle;
-    @NotEmpty
+    @NotNull
     private String questContent;
 }

--- a/src/main/java/kr/hs/mirim/family/dto/request/CreateQuestRequest.java
+++ b/src/main/java/kr/hs/mirim/family/dto/request/CreateQuestRequest.java
@@ -1,0 +1,17 @@
+package kr.hs.mirim.family.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateQuestRequest {
+    @NotEmpty
+    private String questTitle;
+    @NotEmpty
+    private String questContent;
+}

--- a/src/main/java/kr/hs/mirim/family/entity/group/repository/GroupRepository.java
+++ b/src/main/java/kr/hs/mirim/family/entity/group/repository/GroupRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.repository.CrudRepository;
 
 import java.util.Optional;
 
-public interface GroupRepository extends CrudRepository<Group, Long>,  GroupRepositoryExtension{
+public interface GroupRepository extends CrudRepository<Group, Long>, GroupRepositoryExtension {
     boolean existsByGroupInviteCode(String code);
 
     Optional<Group> findByGroupInviteCode(String code);

--- a/src/main/java/kr/hs/mirim/family/entity/quest/Quest.java
+++ b/src/main/java/kr/hs/mirim/family/entity/quest/Quest.java
@@ -26,7 +26,7 @@ public class Quest extends BaseEntity {
     private String questContent;
 
     @Column(name = "accept_user_id", nullable = false)
-    private int acceptUserId;
+    private Long acceptUserId;
 
     @Column(name = "complete_check", nullable = false)
     private boolean completeCheck;
@@ -40,7 +40,7 @@ public class Quest extends BaseEntity {
     private Group group;
 
     @Builder
-    public Quest(String questTitle, String questContent, int acceptUserId, boolean completeCheck, User user, Group group){
+    public Quest(String questTitle, String questContent, Long acceptUserId, boolean completeCheck, User user, Group group) {
         this.questTitle = questTitle;
         this.questContent = questContent;
         this.acceptUserId = acceptUserId;

--- a/src/main/java/kr/hs/mirim/family/entity/quest/repository/QuestRepository.java
+++ b/src/main/java/kr/hs/mirim/family/entity/quest/repository/QuestRepository.java
@@ -1,0 +1,7 @@
+package kr.hs.mirim.family.entity.quest.repository;
+
+import kr.hs.mirim.family.entity.quest.Quest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestRepository extends JpaRepository<Quest, Long> {
+}

--- a/src/main/java/kr/hs/mirim/family/service/QuestService.java
+++ b/src/main/java/kr/hs/mirim/family/service/QuestService.java
@@ -37,7 +37,14 @@ public class QuestService {
         formValidate(bindingResult);
         existsGroup(groupId);
         User user = existsUser(userId);
-        Quest quest = new Quest(request.getQuestTitle(), request.getQuestContent(), (long) -1, false, user, user.getGroup());
+        Quest quest = Quest.builder()
+                .questTitle(request.getQuestTitle())
+                .questContent(request.getQuestContent())
+                .acceptUserId((long) -1)
+                .completeCheck(false)
+                .user(user)
+                .group(user.getGroup())
+                .build();
         questRepository.save(quest);
     }
 

--- a/src/main/java/kr/hs/mirim/family/service/QuestService.java
+++ b/src/main/java/kr/hs/mirim/family/service/QuestService.java
@@ -19,6 +19,20 @@ public class QuestService {
     private final UserRepository userRepository;
     private final GroupRepository groupRepository;
 
+    /* *
+     * 심부름 추가 기능
+     * 심부름 추가 완료 시 200 OK
+     *
+     * dto form이 일치하지 않으면 400 Bad request
+     * 그룹이 존재하지 않으면 404 Not found
+     * 계정이 존재하지 않으면 404 Not found
+     *
+     * Quest Entity의 기본값 세팅
+     * - acceptUserId : 심부름 수락자의 id로, 심부름 추가 시 수락자가 없으므로 기본값 -1
+     * - completeCheck : 심부름 수락자가 심부름을 완료했을 경우 true, 아닐 경우 기본값 false
+     *
+     * @author: m04j00
+     * */
     public void createQuest(long groupId, long userId, CreateQuestRequest request, BindingResult bindingResult) {
         formValidate(bindingResult);
         existsGroup(groupId);

--- a/src/main/java/kr/hs/mirim/family/service/QuestService.java
+++ b/src/main/java/kr/hs/mirim/family/service/QuestService.java
@@ -1,0 +1,48 @@
+package kr.hs.mirim.family.service;
+
+import kr.hs.mirim.family.dto.request.CreateQuestRequest;
+import kr.hs.mirim.family.entity.group.repository.GroupRepository;
+import kr.hs.mirim.family.entity.quest.Quest;
+import kr.hs.mirim.family.entity.quest.repository.QuestRepository;
+import kr.hs.mirim.family.entity.user.User;
+import kr.hs.mirim.family.entity.user.repository.UserRepository;
+import kr.hs.mirim.family.exception.BadRequestException;
+import kr.hs.mirim.family.exception.DataNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.validation.BindingResult;
+
+@Service
+@RequiredArgsConstructor
+public class QuestService {
+    private final QuestRepository questRepository;
+    private final UserRepository userRepository;
+    private final GroupRepository groupRepository;
+
+    public void createQuest(long groupId, long userId, CreateQuestRequest request, BindingResult bindingResult) {
+        formValidate(bindingResult);
+        existsGroup(groupId);
+        User user = existsUser(userId);
+        Quest quest = new Quest(request.getQuestTitle(), request.getQuestContent(), (long) -1, false, user, user.getGroup());
+        questRepository.save(quest);
+    }
+
+    private void formValidate(BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            throw new BadRequestException("유효하지 않은 형식입니다.");
+        }
+    }
+
+    private void existsGroup(long groupId) {
+        if (!groupRepository.existsById(groupId)) {
+            throw new DataNotFoundException("존재하지 않는 그룹입니다.");
+        }
+    }
+
+    private User existsUser(long userId) {
+        return userRepository.findById(userId).orElseThrow(() -> {
+            throw new DataNotFoundException("존재하지 않는 회원입니다.");
+        });
+    }
+
+}


### PR DESCRIPTION
- 심부름 추가 기능 구현
  - 400 bad request : dto form이 유효하지 않을 시
  - 404 not fount : 그룹 존재하지 않을 시, 계정 존재하지 않을 시 
- Quest Entity의 acceptUserId의 type이 int형이라서 userId의 type인 long형과 일치하도록 long형으로 변경