### PR TITLE
#77 식재료 일괄 수정 기능 구현

### DIFF
--- a/src/main/java/kr/hs/mirim/family/controller/IngredientController.java
+++ b/src/main/java/kr/hs/mirim/family/controller/IngredientController.java
@@ -2,6 +2,7 @@ package kr.hs.mirim.family.controller;
 
 import kr.hs.mirim.family.dto.request.DeleteIngredientRequest;
 import kr.hs.mirim.family.dto.request.IngredientRequest;
+import kr.hs.mirim.family.dto.request.UpdateIngredientCountRequest;
 import kr.hs.mirim.family.dto.response.IngredientListResponse;
 import kr.hs.mirim.family.service.IngredientService;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +37,17 @@ public class IngredientController {
     }
 
     @DeleteMapping
-    public void deleteIngredient(@PathVariable long groupId, @RequestBody @Valid DeleteIngredientRequest request, BindingResult result){
+    public void deleteIngredient(@PathVariable long groupId,
+                                 @RequestBody @Valid DeleteIngredientRequest request,
+                                 BindingResult result){
         ingredientService.deleteIngredient(groupId, request, result);
     }
+
+    @PutMapping()
+    public void updateIngredientCount(@PathVariable long groupId,
+                                      @RequestBody @Valid UpdateIngredientCountRequest request,
+                                      BindingResult result){
+        ingredientService.updateIngredientCount(groupId, request, result);
+    }
+
 }

--- a/src/main/java/kr/hs/mirim/family/controller/IngredientController.java
+++ b/src/main/java/kr/hs/mirim/family/controller/IngredientController.java
@@ -43,7 +43,7 @@ public class IngredientController {
         ingredientService.deleteIngredient(groupId, request, result);
     }
 
-    @PutMapping()
+    @PutMapping
     public void updateIngredientCount(@PathVariable long groupId,
                                       @RequestBody @Valid UpdateIngredientCountRequest request,
                                       BindingResult result){

--- a/src/main/java/kr/hs/mirim/family/dto/request/UpdateIngredientCountDataRequest.java
+++ b/src/main/java/kr/hs/mirim/family/dto/request/UpdateIngredientCountDataRequest.java
@@ -1,0 +1,19 @@
+package kr.hs.mirim.family.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateIngredientCountDataRequest {
+
+    @NotNull
+    private long ingredientId;
+
+    @NotNull
+    private String ingredientCount;
+}

--- a/src/main/java/kr/hs/mirim/family/dto/request/UpdateIngredientCountRequest.java
+++ b/src/main/java/kr/hs/mirim/family/dto/request/UpdateIngredientCountRequest.java
@@ -1,0 +1,14 @@
+package kr.hs.mirim.family.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateIngredientCountRequest {
+    List<UpdateIngredientCountDataRequest> data;
+}

--- a/src/main/java/kr/hs/mirim/family/entity/ingredient/repository/IngredientRepositoryExtension.java
+++ b/src/main/java/kr/hs/mirim/family/entity/ingredient/repository/IngredientRepositoryExtension.java
@@ -6,4 +6,5 @@ import java.util.List;
 
 public interface IngredientRepositoryExtension {
     List<IngredientListResponse> ingredientSaveTypeList(long groupId, String saveType);
+    void ingredientCountUpdate(long groupId, long ingredientId, String ingredientCount);
 }

--- a/src/main/java/kr/hs/mirim/family/entity/ingredient/repository/IngredientRepositoryImpl.java
+++ b/src/main/java/kr/hs/mirim/family/entity/ingredient/repository/IngredientRepositoryImpl.java
@@ -1,14 +1,17 @@
 package kr.hs.mirim.family.entity.ingredient.repository;
 
+import com.querydsl.core.dml.UpdateClause;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.querydsl.jpa.impl.JPAUpdateClause;
 import kr.hs.mirim.family.dto.response.IngredientListResponse;
 import kr.hs.mirim.family.entity.ingredient.Ingredient;
 import kr.hs.mirim.family.entity.ingredient.IngredientSaveType;
 import kr.hs.mirim.family.entity.ingredient.QIngredient;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -37,6 +40,15 @@ public class IngredientRepositoryImpl extends QuerydslRepositorySupport implemen
                 .from(ingredient)
                 .where(ingredient.group.groupId.eq(groupId), eqSaveType(saveType))
                 .fetch();
+    }
+
+    @Override
+    @Transactional
+    public void ingredientCountUpdate(long groupId, long ingredientId, String ingredientCount) {
+        UpdateClause<JPAUpdateClause> updateBuilder = update(ingredient);
+        updateBuilder.set(ingredient.ingredientCount, ingredientCount);
+
+        updateBuilder.where(ingredient.ingredientId.eq(ingredientId)).execute();
     }
 
     private BooleanExpression eqSaveType(String saveType){

--- a/src/main/java/kr/hs/mirim/family/entity/ingredient/repository/IngredientRepositoryImpl.java
+++ b/src/main/java/kr/hs/mirim/family/entity/ingredient/repository/IngredientRepositoryImpl.java
@@ -48,7 +48,7 @@ public class IngredientRepositoryImpl extends QuerydslRepositorySupport implemen
         UpdateClause<JPAUpdateClause> updateBuilder = update(ingredient);
         updateBuilder.set(ingredient.ingredientCount, ingredientCount);
 
-        updateBuilder.where(ingredient.ingredientId.eq(ingredientId)).execute();
+        updateBuilder.where(ingredient.ingredientId.eq(ingredientId), ingredient.group.groupId.eq(groupId)).execute();
     }
 
     private BooleanExpression eqSaveType(String saveType){

--- a/src/main/java/kr/hs/mirim/family/service/IngredientService.java
+++ b/src/main/java/kr/hs/mirim/family/service/IngredientService.java
@@ -2,6 +2,7 @@ package kr.hs.mirim.family.service;
 
 import kr.hs.mirim.family.dto.request.DeleteIngredientRequest;
 import kr.hs.mirim.family.dto.request.IngredientRequest;
+import kr.hs.mirim.family.dto.request.UpdateIngredientCountRequest;
 import kr.hs.mirim.family.dto.response.IngredientListResponse;
 import kr.hs.mirim.family.entity.group.Group;
 import kr.hs.mirim.family.entity.group.repository.GroupRepository;
@@ -82,6 +83,27 @@ public class IngredientService {
             existIngredientInGroup(groupId, ingredient);
 
             ingredientRepository.deleteById(ingredient.getIngredientId());
+        }
+    }
+
+    @Transactional
+    public void updateIngredientCount(long groupId, UpdateIngredientCountRequest request, BindingResult result){
+        formValidate(result);
+        existGroup(groupId);
+
+        for(int i=0; i<request.getData().size(); i++){
+            Ingredient ingredient = getIngredient(request.getData().get(i).getIngredientId());
+            existIngredientInGroup(groupId, ingredient);
+
+            String requestCount = request.getData().get(i).getIngredientCount();
+            long requestIngredientId = request.getData().get(i).getIngredientId();
+
+            if(checkIngredientCount(requestCount)){
+                ingredientRepository.deleteById(requestIngredientId);
+            }
+            else {
+                ingredientRepository.ingredientCountUpdate(groupId, requestIngredientId, requestCount);
+            }
         }
     }
 


### PR DESCRIPTION
- 식재료의 수가 0일 경우(0g,0개 모두 포함) 해당 식재료를 삭제
- 그 외 경우 들어온 식재료의 카운트에 맞게 업데이트


`404 not found`
- 해당하는 식재료가 없을 경우 
- 해당하는 그룹이 없을 경우
- 식재료는 있지만 그룹 안에 있는 식재료가 아닐 경우
