### PR TITLE
#111 회원이 그룹에 가입되어있는지 확인 

### DIFF
--- a/src/main/java/kr/hs/mirim/family/service/UserService.java
+++ b/src/main/java/kr/hs/mirim/family/service/UserService.java
@@ -54,6 +54,7 @@ public class UserService {
 
         //존재하는 이메일인지 확인
         User user = userRepository.findByUserEmail(loginUserRequest.getUserEmail()).orElseThrow(() -> new DataNotFoundException("존재하지 않는 회원입니다."));
+        groupCheck(user);
 
         //이메일과 비밀번호가 맞지 않을때
         if(!passwordEncoder.matches(loginUserRequest.getUserPassword(), user.getUserPassword())){
@@ -164,6 +165,13 @@ public class UserService {
     private void passwordCheck(User user, String userPassword){
         if(!passwordEncoder.matches(userPassword, user.getUserPassword())){
             throw new ForbiddenException("회원 정보가 일치하지 않습니다.");
+        }
+    }
+
+    private void groupCheck(User user){
+        //회원이 그룹에 가입되어 있는지 확인
+        if(user.getGroup()==null){
+            throw new DataNotFoundException("그룹에 가입되어 있지 않은 회원입니다.");
         }
     }
 


### PR DESCRIPTION
* 배포 중 발생한 bug(에러)를 처리하였습니다.
* 로그인 기능에서 회원이 그룹에 가입되어있는지 확인 후, 가입되어 있지 않다면 `그룹에 가입되어있지 않은 회원입니다.` 라는 예외를 반환합니다.
* 비밀번호 수정에서 회원이 그룹에 가입되었는지 확인하는 기능은 로그인에서 체크하므로 UI 흐름상 필요치 않아 예외처리 하지 않았습니다.