### PR TITLE
#169 로그인 시 그룹에 가입하지 않은 회원, 그룹 null 반환 처리

### DIFF
--- a/src/main/java/kr/hs/mirim/family/service/UserService.java
+++ b/src/main/java/kr/hs/mirim/family/service/UserService.java
@@ -61,22 +61,33 @@ public class UserService {
 
         //존재하는 이메일인지 확인
         User user = userRepository.findByUserEmail(loginUserRequest.getUserEmail()).orElseThrow(() -> new DataNotFoundException("존재하지 않는 회원입니다."));
-        groupCheck(user);
 
         //이메일과 비밀번호가 맞지 않을때
         if(!passwordEncoder.matches(loginUserRequest.getUserPassword(), user.getUserPassword())){
             throw new ForbiddenException("회원 정보가 일치하지 않습니다.");
         }
 
-        return LoginUserResponse.builder()
-                .userId(user.getUserId())
-                .userName(user.getUserName())
-                .userNickname(user.getUserNickname())
-                .userEmail(user.getUserEmail())
-                .userImagePath(user.getUserImagePath())
-                .groupId(user.getGroup().getGroupId())
-                .groupInviteCode(user.getGroup().getGroupInviteCode())
-                .build();
+        if(groupCheck(user)){
+            return LoginUserResponse.builder()
+                    .userId(user.getUserId())
+                    .userName(user.getUserName())
+                    .userNickname(user.getUserNickname())
+                    .userEmail(user.getUserEmail())
+                    .userImagePath(user.getUserImagePath())
+                    .groupId(user.getGroup().getGroupId())
+                    .groupInviteCode(user.getGroup().getGroupInviteCode())
+                    .build();
+        }else{
+            return LoginUserResponse.builder()
+                    .userId(user.getUserId())
+                    .userName(user.getUserName())
+                    .userNickname(user.getUserNickname())
+                    .userEmail(user.getUserEmail())
+                    .userImagePath(user.getUserImagePath())
+                    .groupId(null)
+                    .groupInviteCode(null)
+                    .build();
+        }
     }
 
     @Transactional
@@ -183,11 +194,9 @@ public class UserService {
         }
     }
 
-    private void groupCheck(User user){
+    private boolean groupCheck(User user){
         //회원이 그룹에 가입되어 있는지 확인
-        if(user.getGroup()==null){
-            throw new DataNotFoundException("그룹에 가입되어 있지 않은 회원입니다.");
-        }
+        return user.getGroup() != null;
     }
 
     private void formValidateException(BindingResult bindingResult){

--- a/src/main/java/kr/hs/mirim/family/service/UserService.java
+++ b/src/main/java/kr/hs/mirim/family/service/UserService.java
@@ -67,27 +67,22 @@ public class UserService {
             throw new ForbiddenException("회원 정보가 일치하지 않습니다.");
         }
 
+        Long groupId = null;
+        String groupInviteCode = null;
         if(groupCheck(user)){
-            return LoginUserResponse.builder()
-                    .userId(user.getUserId())
-                    .userName(user.getUserName())
-                    .userNickname(user.getUserNickname())
-                    .userEmail(user.getUserEmail())
-                    .userImagePath(user.getUserImagePath())
-                    .groupId(user.getGroup().getGroupId())
-                    .groupInviteCode(user.getGroup().getGroupInviteCode())
-                    .build();
-        }else{
-            return LoginUserResponse.builder()
-                    .userId(user.getUserId())
-                    .userName(user.getUserName())
-                    .userNickname(user.getUserNickname())
-                    .userEmail(user.getUserEmail())
-                    .userImagePath(user.getUserImagePath())
-                    .groupId(null)
-                    .groupInviteCode(null)
-                    .build();
+            groupId = user.getGroup().getGroupId();
+            groupInviteCode = user.getGroup().getGroupInviteCode();
         }
+
+        return LoginUserResponse.builder()
+                .userId(user.getUserId())
+                .userName(user.getUserName())
+                .userNickname(user.getUserNickname())
+                .userEmail(user.getUserEmail())
+                .userImagePath(user.getUserImagePath())
+                .groupId(groupId)
+                .groupInviteCode(groupInviteCode)
+                .build();
     }
 
     @Transactional


### PR DESCRIPTION
* 로그인시, 예외적인 상황에 의해 회원가입때 그룹 가입이 되지 않은 회원에 대하여 그룹에 가입되지 않았다는 404 에러를 반환하는 것이 아닌, group을 null값으로 반환하여 이후 그룹 가입을 처리할 수 있도록 로직을 변경하였습니다.